### PR TITLE
fix: CQDG-637 client mfa

### DIFF
--- a/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientConditionalOtpFormAuthenticator.java
+++ b/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientConditionalOtpFormAuthenticator.java
@@ -1,0 +1,99 @@
+package bio.ferlab.keycloak.authenticators;//
+
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.browser.OTPFormAuthenticator;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserModel.RequiredAction;
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class ClientConditionalOtpFormAuthenticator extends OTPFormAuthenticator {
+    public static final String FORCE_OTP_CLIENT = "forceOtpClient";
+    public static final String CLIENT_ID = "client_id";
+
+    public ClientConditionalOtpFormAuthenticator() {
+    }
+
+    public void authenticate(AuthenticationFlowContext context) {
+        Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+        OtpDecision clientDecision = voteForClient(context.getUriInfo().getQueryParameters(), config);
+
+        if(clientDecision == OtpDecision.SHOW_OTP){
+            showOtpForm(context);
+        } else context.success();
+    }
+
+    private boolean tryConcludeBasedOn(OtpDecision state) {
+        switch (state) {
+            case SHOW_OTP:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void showOtpForm(AuthenticationFlowContext context) {
+        super.authenticate(context);
+    }
+
+    private OtpDecision voteForClient(MultivaluedMap<String, String> queryParameters, Map<String, String> config) {
+        if (queryParameters.containsKey(CLIENT_ID) && config.containsKey(FORCE_OTP_CLIENT)) {
+            return queryParameters.get(CLIENT_ID).contains(config.get(FORCE_OTP_CLIENT)) ?
+                    OtpDecision.SHOW_OTP : OtpDecision.ABSTAIN;
+        } else return OtpDecision.ABSTAIN;
+    }
+
+    private boolean isOTPRequired(KeycloakSession session, RealmModel realm, UserModel user) {
+        MultivaluedMap<String, String> queryParameters = session.getContext().getUri().getQueryParameters();
+
+        return realm.getAuthenticatorConfigsStream().anyMatch((configModel) -> {
+            if (tryConcludeBasedOn(voteForClient(queryParameters, configModel.getConfig()))) {
+                return true;
+            } else {
+                return configModel.getConfig().containsKey(FORCE_OTP_CLIENT) && voteForClient(queryParameters, configModel.getConfig()) == OtpDecision.ABSTAIN;
+            }
+        });
+    }
+
+    private String getFormClient(RealmModel realm) {
+        Optional<AuthenticatorConfigModel> authenticatorConfigModel = realm.getAuthenticatorConfigsStream().filter(c -> c.getConfig().containsKey(FORCE_OTP_CLIENT)).reduce((first, second) -> second);
+        return authenticatorConfigModel.map(configModel -> configModel.getConfig().getOrDefault(FORCE_OTP_CLIENT, null)).orElse(null);
+    };
+
+
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+        String formClient = getFormClient(realm);
+        MultivaluedMap<String, String> queryParameters = session.getContext().getUri().getQueryParameters();
+
+        if (!isOTPRequired(session, realm, user)) {
+            user.removeRequiredAction(RequiredAction.CONFIGURE_TOTP);
+        } else {
+            Stream<String> userRequiredActionsStream = user.getRequiredActionsStream();
+            String configureTOTPAction = RequiredAction.CONFIGURE_TOTP.name();
+            Objects.requireNonNull(configureTOTPAction);
+
+            if (userRequiredActionsStream.noneMatch(configureTOTPAction::equals) && !formClient.isEmpty()) {
+                if(queryParameters.containsKey(CLIENT_ID) && queryParameters.get(CLIENT_ID).contains(formClient)){
+                    user.addRequiredAction(RequiredAction.CONFIGURE_TOTP.name());
+                }
+            }
+        }
+    }
+
+    enum OtpDecision {
+        SKIP_OTP,
+        SHOW_OTP,
+        ABSTAIN;
+
+        OtpDecision() {
+        }
+    }
+}

--- a/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientConditionalOtpFormAuthenticatorFactory.java
+++ b/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientConditionalOtpFormAuthenticatorFactory.java
@@ -1,0 +1,69 @@
+package bio.ferlab.keycloak.authenticators;
+
+import java.util.Arrays;
+import java.util.List;
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class ClientConditionalOtpFormAuthenticatorFactory implements AuthenticatorFactory {
+    public static final String PROVIDER_ID = "client-auth-conditional-otp-form";
+    public static final ClientConditionalOtpFormAuthenticator SINGLETON = new ClientConditionalOtpFormAuthenticator();
+
+    public ClientConditionalOtpFormAuthenticatorFactory() {
+    }
+
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    public void init(Config.Scope config) {
+    }
+
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    public void close() {
+    }
+
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    public String getReferenceCategory() {
+        return "otp";
+    }
+
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    public boolean isUserSetupAllowed() {
+        return true;
+    }
+
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    public String getDisplayType() {
+        return "Client Conditional OTP Form";
+    }
+
+    public String getHelpText() {
+        return "Validates a OTP on a separate OTP form. Only shown if required based on the configured conditions.";
+    }
+
+    public List<ProviderConfigProperty> getConfigProperties() {
+        ProviderConfigProperty forceOtpRole = new ProviderConfigProperty();
+        forceOtpRole.setType(ProviderConfigProperty.CLIENT_LIST_TYPE);
+        forceOtpRole.setName("forceOtpClient");
+        forceOtpRole.setLabel("Force OTP for Client");
+        forceOtpRole.setHelpText("OTP is always required if user request the given client");
+        return Arrays.asList(forceOtpRole);
+    }
+}

--- a/cqdg-providers/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/cqdg-providers/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,2 +1,3 @@
 bio.ferlab.keycloak.authenticators.EmailWhitelistAuthenticatorFactory
 bio.ferlab.keycloak.authenticators.UserProfileExistAuthenticatorFactory
+bio.ferlab.keycloak.authenticators.ClientConditionalOtpFormAuthenticatorFactory


### PR DESCRIPTION
1. Custom **Client Contitional Form**
a. Assign the target client for 2FA. (`test-ferload` in this case)
b. Default behaviour is Skip. We'll do this for all other clients 

![Screenshot from 2024-06-04 15-43-11](https://github.com/Ferlab-Ste-Justine/cqdg-keycloak/assets/29788342/6706c269-f9af-4100-92d0-389e7bb02ad8)

2. Add flow to provider(s):

![Screenshot from 2024-06-04 15-41-38](https://github.com/Ferlab-Ste-Justine/cqdg-keycloak/assets/29788342/a48d9587-ed63-4907-b143-20d9bd88c5d9)

3. Testing with 2 clients set (`test-ferload` and `test-ferload-2`)
a. test-ferload:

![Screenshot from 2024-06-04 15-50-39](https://github.com/Ferlab-Ste-Justine/cqdg-keycloak/assets/29788342/814ac745-a6cb-48e8-a117-e432e439c280)
                                             :arrow_double_down:
![Screenshot from 2024-06-04 15-52-56](https://github.com/Ferlab-Ste-Justine/cqdg-keycloak/assets/29788342/e8a63758-ab78-4635-af39-1e7e4988a4e2)
                                             :arrow_double_down:
![Screenshot from 2024-06-04 15-56-43](https://github.com/Ferlab-Ste-Justine/cqdg-keycloak/assets/29788342/84606d85-3323-4a5b-a451-b027e20fa94b)

 
 
 b. test-ferload-2:

![Screenshot from 2024-06-04 15-50-39](https://github.com/Ferlab-Ste-Justine/cqdg-keycloak/assets/29788342/814ac745-a6cb-48e8-a117-e432e439c280)
                                             :arrow_double_down:
![Screenshot from 2024-06-04 15-56-43](https://github.com/Ferlab-Ste-Justine/cqdg-keycloak/assets/29788342/1d37f1b5-c730-4016-aa87-d7812aab5f3d)
