### PR TITLE
fix: CQDG-637 cookie disable for client

### DIFF
--- a/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientConditionalOtpFormAuthenticator.java
+++ b/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientConditionalOtpFormAuthenticator.java
@@ -14,9 +14,9 @@ import java.util.*;
 import java.util.stream.Stream;
 
 public class ClientConditionalOtpFormAuthenticator extends OTPFormAuthenticator {
-    public static final String FORCE_OTP_CLIENT = "forceOtpClients";
+    public static final String FORCE_OTP_CLIENTS = "forceOtpClients";
     public static final String CLIENT_ID = "client_id";
-    private static final String[] EMPTY_ARRAY = new String[0];
+    private static final String CLIENTS_SEPARATOR = "##";
 
     public ClientConditionalOtpFormAuthenticator() {
     }
@@ -43,14 +43,14 @@ public class ClientConditionalOtpFormAuthenticator extends OTPFormAuthenticator 
         super.authenticate(context);
     }
 
-    private boolean isClientsMatch(MultivaluedMap<String, String> queryParameters, String[] formClients) {
+    private boolean isClientsMatch(MultivaluedMap<String, String> queryParameters, List<String> formClients) {
         Optional<String> clientRequest = queryParameters.get(CLIENT_ID).stream().reduce((first, second) -> second).map(String::toLowerCase);
-        return clientRequest.filter(clReq -> Arrays.asList(formClients).contains(clReq)).isPresent();
+        return clientRequest.filter(formClients::contains).isPresent();
     }
 
     private OtpDecision voteForClient(MultivaluedMap<String, String> queryParameters, Map<String, String> config) {
-        if (queryParameters.containsKey(CLIENT_ID) && config.containsKey(FORCE_OTP_CLIENT)) {
-            String[] formClients = config.get(FORCE_OTP_CLIENT).trim().toLowerCase().split("##");
+        if (queryParameters.containsKey(CLIENT_ID) && config.containsKey(FORCE_OTP_CLIENTS)) {
+            List<String> formClients = Arrays.stream(config.get(FORCE_OTP_CLIENTS).trim().toLowerCase().split(CLIENTS_SEPARATOR)).toList();
             return isClientsMatch(queryParameters, formClients) ? OtpDecision.SHOW_OTP : OtpDecision.ABSTAIN;
         } else return OtpDecision.ABSTAIN;
     }
@@ -62,20 +62,20 @@ public class ClientConditionalOtpFormAuthenticator extends OTPFormAuthenticator 
             if (tryConcludeBasedOn(voteForClient(queryParameters, configModel.getConfig()))) {
                 return true;
             } else {
-                return configModel.getConfig().containsKey(FORCE_OTP_CLIENT) && voteForClient(queryParameters, configModel.getConfig()) == OtpDecision.ABSTAIN;
+                return configModel.getConfig().containsKey(FORCE_OTP_CLIENTS) && voteForClient(queryParameters, configModel.getConfig()) == OtpDecision.ABSTAIN;
             }
         });
     }
 
-    private String[] getFormClients(RealmModel realm) {
-        Optional<AuthenticatorConfigModel> authenticatorConfigModel = realm.getAuthenticatorConfigsStream().filter(c -> c.getConfig().containsKey(FORCE_OTP_CLIENT)).reduce((first, second) -> second);
+    private List<String> getFormClients(RealmModel realm) {
+        Optional<AuthenticatorConfigModel> authenticatorConfigModel = realm.getAuthenticatorConfigsStream().filter(c -> c.getConfig().containsKey(FORCE_OTP_CLIENTS)).reduce((first, second) -> second);
 
-        return authenticatorConfigModel.map(configModel -> configModel.getConfig().get(FORCE_OTP_CLIENT).trim().toLowerCase().split("##")).orElse(EMPTY_ARRAY);
+        return authenticatorConfigModel.map(configModel -> Arrays.stream(configModel.getConfig().get(FORCE_OTP_CLIENTS).trim().toLowerCase().split(CLIENTS_SEPARATOR)).toList()).orElse(Collections.emptyList());
     };
 
 
     public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
-        String[] formClients = getFormClients(realm);
+        List<String> formClients = getFormClients(realm);
         MultivaluedMap<String, String> queryParameters = session.getContext().getUri().getQueryParameters();
 
         if (!isOTPRequired(session, realm, user)) {
@@ -85,7 +85,7 @@ public class ClientConditionalOtpFormAuthenticator extends OTPFormAuthenticator 
             String configureTOTPAction = RequiredAction.CONFIGURE_TOTP.name();
             Objects.requireNonNull(configureTOTPAction);
 
-            if (userRequiredActionsStream.noneMatch(configureTOTPAction::equals) && formClients != EMPTY_ARRAY) {
+            if (userRequiredActionsStream.noneMatch(configureTOTPAction::equals) && !formClients.isEmpty()) {
                 if(queryParameters.containsKey(CLIENT_ID) && isClientsMatch(queryParameters, formClients)){
                     user.addRequiredAction(RequiredAction.CONFIGURE_TOTP.name());
                 }

--- a/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientConditionalOtpFormAuthenticatorFactory.java
+++ b/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientConditionalOtpFormAuthenticatorFactory.java
@@ -1,16 +1,14 @@
 package bio.ferlab.keycloak.authenticators;
 
-import java.util.Arrays;
-import java.util.List;
-import org.keycloak.Config;
 import org.keycloak.authentication.Authenticator;
-import org.keycloak.authentication.AuthenticatorFactory;
-import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.authentication.authenticators.browser.OTPFormAuthenticatorFactory;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 
-public class ClientConditionalOtpFormAuthenticatorFactory implements AuthenticatorFactory {
+import java.util.Arrays;
+import java.util.List;
+
+public class ClientConditionalOtpFormAuthenticatorFactory extends OTPFormAuthenticatorFactory {
     public static final String PROVIDER_ID = "client-auth-conditional-otp-form";
     public static final ClientConditionalOtpFormAuthenticator SINGLETON = new ClientConditionalOtpFormAuthenticator();
 
@@ -21,33 +19,12 @@ public class ClientConditionalOtpFormAuthenticatorFactory implements Authenticat
         return SINGLETON;
     }
 
-    public void init(Config.Scope config) {
-    }
-
-    public void postInit(KeycloakSessionFactory factory) {
-    }
-
-    public void close() {
-    }
-
     public String getId() {
         return PROVIDER_ID;
     }
 
-    public String getReferenceCategory() {
-        return "otp";
-    }
-
     public boolean isConfigurable() {
         return true;
-    }
-
-    public boolean isUserSetupAllowed() {
-        return true;
-    }
-
-    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
-        return REQUIREMENT_CHOICES;
     }
 
     public String getDisplayType() {
@@ -60,10 +37,11 @@ public class ClientConditionalOtpFormAuthenticatorFactory implements Authenticat
 
     public List<ProviderConfigProperty> getConfigProperties() {
         ProviderConfigProperty forceOtpRole = new ProviderConfigProperty();
-        forceOtpRole.setType(ProviderConfigProperty.CLIENT_LIST_TYPE);
-        forceOtpRole.setName("forceOtpClient");
-        forceOtpRole.setLabel("Force OTP for Client");
-        forceOtpRole.setHelpText("OTP is always required if user request the given client");
+        forceOtpRole.setType(ProviderConfigProperty.MULTIVALUED_STRING_TYPE); //free text
+        forceOtpRole.setName("forceOtpClients");
+        forceOtpRole.setLabel("Force OTP for Clients");
+        forceOtpRole.setHelpText("OTP is always required if user request the given clients");
+
         return Arrays.asList(forceOtpRole);
     }
 }

--- a/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientExcludedCookieAuthenticator.java
+++ b/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientExcludedCookieAuthenticator.java
@@ -1,0 +1,80 @@
+package bio.ferlab.keycloak.authenticators;//
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.authenticators.util.AcrStore;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.protocol.LoginProtocol;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ClientExcludedCookieAuthenticator implements Authenticator {
+    private static final String CLIENT_ID = "client_id";
+
+    public ClientExcludedCookieAuthenticator() {
+    }
+
+    public boolean requiresUser() {
+        return false;
+    }
+
+    public void authenticate(AuthenticationFlowContext context) {
+        AuthenticationManager.AuthResult authResult = AuthenticationManager.authenticateIdentityCookie(context.getSession(), context.getRealm(), true);
+
+        if (authResult == null || isExcludedClient(context)) {
+            context.attempted();
+        } else {
+            AuthenticationSessionModel authSession = context.getAuthenticationSession();
+            LoginProtocol protocol = (LoginProtocol)context.getSession().getProvider(LoginProtocol.class, authSession.getProtocol());
+            authSession.setAuthNote("loa-map", authResult.getSession().getNote("loa-map"));
+            context.setUser(authResult.getUser());
+            AcrStore acrStore = new AcrStore(authSession);
+            if (protocol.requireReauthentication(authResult.getSession(), authSession)) {
+                acrStore.setLevelAuthenticatedToCurrentRequest(-1);
+                authSession.setAuthNote("FORCED_REAUTHENTICATION", "true");
+                context.setForwardedInfoMessage("reauthenticate", new Object[0]);
+                context.attempted();
+            } else {
+                int previouslyAuthenticatedLevel = acrStore.getHighestAuthenticatedLevelFromPreviousAuthentication();
+                if (acrStore.getRequestedLevelOfAuthentication() > previouslyAuthenticatedLevel) {
+                    acrStore.setLevelAuthenticatedToCurrentRequest(previouslyAuthenticatedLevel);
+                    context.attempted();
+                } else {
+                    acrStore.setLevelAuthenticatedToCurrentRequest(previouslyAuthenticatedLevel);
+                    authSession.setAuthNote("SSO_AUTH", "true");
+                    context.attachUserSession(authResult.getSession());
+                    context.success();
+                }
+            }
+        }
+
+    }
+
+    public void action(AuthenticationFlowContext context) {
+    }
+
+    private boolean isExcludedClient(AuthenticationFlowContext context) {
+        MultivaluedMap<String, String> queryParameters = context.getUriInfo().getQueryParameters();
+
+        Optional<String> clientRequest = queryParameters.get(CLIENT_ID).stream().reduce((first, second) -> second);
+        String clientForm =  context.getAuthenticatorConfig().getConfig().get("forceReAuthForClient");
+
+        return clientRequest.filter(s -> Objects.equals(clientForm, s)).isPresent();
+    }
+
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+    }
+
+    public void close() {
+    }
+}

--- a/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientExcludedCookieAuthenticatorFactory.java
+++ b/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientExcludedCookieAuthenticatorFactory.java
@@ -1,0 +1,69 @@
+package bio.ferlab.keycloak.authenticators;//
+
+import java.util.Arrays;
+import java.util.List;
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class ClientExcludedCookieAuthenticatorFactory implements AuthenticatorFactory {
+    public static final String PROVIDER_ID = "auth-cookie-client-exclude";
+    static ClientExcludedCookieAuthenticator SINGLETON = new ClientExcludedCookieAuthenticator();
+
+    public ClientExcludedCookieAuthenticatorFactory() {
+    }
+
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    public void init(Config.Scope config) {
+    }
+
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    public void close() {
+    }
+
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    public String getReferenceCategory() {
+        return "cookie";
+    }
+
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    public String getDisplayType() {
+        return "Cookie Exclude Client";
+    }
+
+    public String getHelpText() {
+        return "Validates the SSO cookie set by the auth server, except for the set client";
+    }
+
+    public List<ProviderConfigProperty> getConfigProperties() {
+        ProviderConfigProperty forceReAuthClient = new ProviderConfigProperty();
+        forceReAuthClient.setType(ProviderConfigProperty.CLIENT_LIST_TYPE);
+        forceReAuthClient.setName("forceReAuthForClient");
+        forceReAuthClient.setLabel("Force Re-Authentication for Client");
+        forceReAuthClient.setHelpText("Disable SSO cookie validation for set client (force re-authentication)");
+        return Arrays.asList(forceReAuthClient);
+    }
+
+    public boolean isUserSetupAllowed() {
+        return true;
+    }
+}

--- a/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientExcludedCookieAuthenticatorFactory.java
+++ b/cqdg-providers/src/main/java/bio/ferlab/keycloak/authenticators/ClientExcludedCookieAuthenticatorFactory.java
@@ -1,49 +1,31 @@
 package bio.ferlab.keycloak.authenticators;//
 
-import java.util.Arrays;
-import java.util.List;
-import org.keycloak.Config;
 import org.keycloak.authentication.Authenticator;
-import org.keycloak.authentication.AuthenticatorFactory;
-import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.authentication.authenticators.browser.CookieAuthenticatorFactory;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 
-public class ClientExcludedCookieAuthenticatorFactory implements AuthenticatorFactory {
+import java.util.Arrays;
+import java.util.List;
+
+public class ClientExcludedCookieAuthenticatorFactory extends CookieAuthenticatorFactory {
     public static final String PROVIDER_ID = "auth-cookie-client-exclude";
     static ClientExcludedCookieAuthenticator SINGLETON = new ClientExcludedCookieAuthenticator();
 
     public ClientExcludedCookieAuthenticatorFactory() {
     }
 
+
     public Authenticator create(KeycloakSession session) {
         return SINGLETON;
-    }
-
-    public void init(Config.Scope config) {
-    }
-
-    public void postInit(KeycloakSessionFactory factory) {
-    }
-
-    public void close() {
     }
 
     public String getId() {
         return PROVIDER_ID;
     }
 
-    public String getReferenceCategory() {
-        return "cookie";
-    }
-
     public boolean isConfigurable() {
         return true;
-    }
-
-    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
-        return REQUIREMENT_CHOICES;
     }
 
     public String getDisplayType() {
@@ -54,12 +36,14 @@ public class ClientExcludedCookieAuthenticatorFactory implements AuthenticatorFa
         return "Validates the SSO cookie set by the auth server, except for the set client";
     }
 
+
     public List<ProviderConfigProperty> getConfigProperties() {
         ProviderConfigProperty forceReAuthClient = new ProviderConfigProperty();
-        forceReAuthClient.setType(ProviderConfigProperty.CLIENT_LIST_TYPE);
+        forceReAuthClient.setType(ProviderConfigProperty.MULTIVALUED_STRING_TYPE); //free text
         forceReAuthClient.setName("forceReAuthForClient");
         forceReAuthClient.setLabel("Force Re-Authentication for Client");
         forceReAuthClient.setHelpText("Disable SSO cookie validation for set client (force re-authentication)");
+
         return Arrays.asList(forceReAuthClient);
     }
 

--- a/cqdg-providers/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/cqdg-providers/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,3 +1,4 @@
 bio.ferlab.keycloak.authenticators.EmailWhitelistAuthenticatorFactory
 bio.ferlab.keycloak.authenticators.UserProfileExistAuthenticatorFactory
 bio.ferlab.keycloak.authenticators.ClientConditionalOtpFormAuthenticatorFactory
+bio.ferlab.keycloak.authenticators.ClientExcludedCookieAuthenticatorFactory


### PR DESCRIPTION
### Issue: 

2FA is implemented for **Ferload client**. However, we authorise authentication with a cookie (in default Browser flow). This enables the user to bypass the 2FA requirement even when calling the **Ferload client**.
1. Login into the portal (no 2FA required). This will update his cookie.
2. Request the **Ferload client** shortly after. No new login is required and no 2FA is required. Access is granted.

Disabling the Cookie step in Browser flow is not desirable, this will require a new login each time a user wants to access the portal.

### Proposed solution:

Replace the default build-in `Cookie` step in the Browser flow with a new custom made Cooke step that excludes a set client.
Starting from the regular Cookie step (see: `CookieAuthenticator.java` and `CookieAuthenticatorFactory.java`)

1. This custom cookie step has a user input config that enables to set a client (see Factory class).
2. Add an extra condition that forces the re-authentication if the client requested is client set to custom cookie step. This check -> `if (authResult == null || isExcludedClient(context)) `

The rest of the code is the same as the default cookie classes (copied). 

![Screenshot from 2024-06-12 15-12-03](https://github.com/Ferlab-Ste-Justine/cqdg-keycloak/assets/29788342/48f31d1f-0201-42c1-90fd-32c5dc507283)

![Screenshot from 2024-06-17 08-43-32](https://github.com/Ferlab-Ste-Justine/cqdg-keycloak/assets/29788342/f14f8a1e-f32c-46a3-824d-16fdc5ca0e16)

![Screenshot from 2024-06-17 08-44-59](https://github.com/Ferlab-Ste-Justine/cqdg-keycloak/assets/29788342/645afa04-20ad-4bba-8b0c-45b1f8467c55)
